### PR TITLE
Use t3.micro as the default instance type.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "user_data" {
 
 variable "instance_type" {
   description = "Type of instance to provision."
-  default     = "t2.micro"
+  default     = "t3.micro"
 }
 
 variable "instance_ami" {


### PR DESCRIPTION
Note, this is actually a "breaking" change if someone has stuck with the default value.