### PR TITLE
Fix instance policy count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,6 @@ resource "aws_iam_instance_profile" "main" {
 }
 
 resource "aws_iam_role_policy" "main" {
-  count  = var.instance_policy == null ? 0 : 1
   name   = "${var.name_prefix}-permissions"
   role   = aws_iam_role.main.id
   policy = var.instance_policy

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "aws_iam_instance_profile" "main" {
 }
 
 resource "aws_iam_role_policy" "main" {
-  count  = var.instance_policy == "" ? 0 : 1
+  count  = var.instance_policy == null ? 0 : 1
   name   = "${var.name_prefix}-permissions"
   role   = aws_iam_role.main.id
   policy = var.instance_policy

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "ebs_block_devices" {
 variable "instance_policy" {
   description = "A policy document to apply to the instance profile."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "min_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -51,12 +51,6 @@ variable "ebs_block_devices" {
   default     = []
 }
 
-variable "instance_policy" {
-  description = "A policy document to apply to the instance profile."
-  type        = string
-  default     = null
-}
-
 variable "min_size" {
   description = "The minimum (and desired) size of the auto scale group."
   type        = number
@@ -91,5 +85,22 @@ variable "tags" {
   description = "A map of tags (key-value pairs) passed to resources."
   type        = map(string)
   default     = {}
+}
+
+variable "instance_policy" {
+  description = "A policy document to apply to the instance profile."
+  type        = string
+  default     = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "placeholder",
+            "Effect": "Deny",
+            "NotAction": "*",
+            "NotResource": "*"
+        }
+    ]
+EOF
 }
 


### PR DESCRIPTION
I believe we'll need to bring back the default value for `instance_policy` as a placeholder, since I'm seeing issues with calculating count in dependent modules, even though it works fine in the examples in this repo 🤷‍♂ 