### PR TITLE
Fix user data tests

### DIFF
--- a/test/asg.go
+++ b/test/asg.go
@@ -17,7 +17,7 @@ type Expectations struct {
 	MinSize         int64
 	MaxSize         int64
 	DesiredCapacity int64
-	UserData        string
+	UserData        []string
 	InstanceType    string
 	Volumes         []string
 	InstanceTags    map[string]string
@@ -38,7 +38,11 @@ func RunTestSuite(t *testing.T, name, region string, expected Expectations) {
 	assert.Equal(t, expected.DesiredCapacity, aws.Int64Value(group.DesiredCapacity))
 
 	config = DescribeLaunchConfiguration(t, sess, aws.StringValue(group.LaunchConfigurationName))
-	assert.Equal(t, expected.UserData, DecodeUserData(t, config.UserData))
+
+	userData := DecodeUserData(t, config.UserData)
+	for _, data := range expected.UserData {
+		assert.Contains(t, userData, data)
+	}
 
 	// Wait for capacity in the autoscaling group (max 10min wait)
 	WaitForCapacity(t, sess, name, 10*time.Second, 10*time.Minute)

--- a/test/asg_test.go
+++ b/test/asg_test.go
@@ -43,7 +43,7 @@ func TestDefaultExample(t *testing.T) {
 				MinSize:         2,
 				MaxSize:         4,
 				DesiredCapacity: 2,
-				UserData:        "#!bin/bash\necho hello world",
+				UserData:        []string{"#!bin/bash\necho hello world"},
 				InstanceType:    "t3.micro",
 				Volumes: []string{
 					"/dev/xvdcz",

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,7 @@ variable "instance_policy" {
             "NotResource": "*"
         }
     ]
+}
 EOF
 }
 


### PR DESCRIPTION
This gives us more flexibility with regards to what we want to know/ensure is a part of the `user_data` for the launch configuration. So, either we do partial matches by looping over a list of strings and checking whether the configuration `Contains()` the listed strings - OR, we continue to write strict `Equals` tests which are much more complicated.

In my mind, we don't really care about the cloud init, but are much more interested in whether the system works. What we might want to check in the `user_data` are things that are harder to verify from the outside, like log levels etc?