### PR TITLE
Use go mod v2+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/telia-oss/terraform-aws-asg
+module github.com/telia-oss/terraform-aws-asg/v3
 
 go 1.12
 


### PR DESCRIPTION
So, this is my understanding of Go modules:
- If I tag the repository with v2 or higher, then go mod imports in e.g. `terraform-aws-concourse` will expect the import path for the module to end with e.g. `/v3` so it can be pinned to a major version.
- Since the `go.mod` file currently does not end with `v2` (current major) then imports of the module are considered "incompatible" by go mods.

According to [this documentation](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher) the recommendation is to create a new major release when enabling v2+ of modules. So that is what this PR is for, and when/if merged this will become the `v3.0.0` release.